### PR TITLE
Create CNAME for bossyui.io domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+bossyui.io


### PR DESCRIPTION
Needed for domain registration. bossyui.com will be forwarded to bossyui.io