### PR TITLE
BUG-173: Fixed error in gulp file where a folder was being referenced with an …

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,7 +101,7 @@ gulp.task('run-tests', 'Runs all Karma tests', function() {
 
 	return gulp.src('')
 		.pipe(shell([
-			'node sites/sandbox/server.js'
+			'node sites/preview/server.js'
 		]));
 });
 


### PR DESCRIPTION
…outdated name for run-tests. Closes #173. 