### PR TITLE
PREVIEW-161: Fixes the markup on the preview site

### DIFF
--- a/src/scss/core/_layout.scss
+++ b/src/scss/core/_layout.scss
@@ -7,7 +7,8 @@
 	margin-top: 0;
 
 	+ * {
-		margin-top: 1.4rem;
+		//margin-top: 1.4rem;
+                margin-top: 0; // Temp fix for the markup on the preview site
 	}
 }
 

--- a/src/scss/core/_layout.scss
+++ b/src/scss/core/_layout.scss
@@ -1,19 +1,4 @@
 /*
-= global box-sizing
-*/
-
-* {
-	@include prefix(box-sizing, border-box);
-	margin-top: 0;
-
-	+ * {
-		//margin-top: 1.4rem;
-                margin-top: 0; // Temp fix for the markup on the preview site
-	}
-}
-
-
-/*
 = Grid Generation
 */
 .grid {


### PR DESCRIPTION
This margin-top is being applied to all elements, even the ones inside ace-ui, which is causing the markup on the preview site to be very hard to use. Setting it to 0 fixes the problem, but I'm not very familiar with scss so I don't know what other implications this has.